### PR TITLE
Update test-and-release.yml - adapt node versions to 16/18/20

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -22,7 +22,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [14.x]
+                node-version: [18.x]
 
         steps:
             - name: Checkout code
@@ -50,7 +50,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [12.x, 14.x, 16.x]
+                node-version: [16.x, 18.x, 20.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
 
         steps:


### PR DESCRIPTION
This PR adapts the node versions of standard github tests to 16 / 18 / 20.
Node 14 and earlier is no longer supported by ioBroker, node 18 is recommended now.